### PR TITLE
Fixing broken examples in docs

### DIFF
--- a/README
+++ b/README
@@ -16,8 +16,8 @@ Example
     acts_as_list :scope => :todo_list
   end
 
-  todo_list.first.move_to_bottom
-  todo_list.last.move_higher
+  todo_list.todo_items.first.move_to_bottom
+  todo_list.todo_items.last.move_higher
 
 
 Copyright (c) 2007 David Heinemeier Hansson, released under the MIT license

--- a/lib/active_record/acts/list.rb
+++ b/lib/active_record/acts/list.rb
@@ -20,8 +20,8 @@ module ActiveRecord
       #     acts_as_list :scope => :todo_list
       #   end
       #
-      #   todo_list.first.move_to_bottom
-      #   todo_list.last.move_higher
+      #   todo_list.todo_items.first.move_to_bottom
+      #   todo_list.todo_items.last.move_higher
       module ClassMethods
         # Configuration options are:
         #


### PR DESCRIPTION
Fixing broken examples in docs, incorrectly stated todo_list.first, should be todo_list.todo_items.first, etc.
